### PR TITLE
feat: make output location optional

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -45,7 +45,11 @@ program
         sourceFile: options.sourceFile as string,
         output: options.output as string,
       });
-      console.info(downloadedFile);
+      if (downloadedFile) {
+        console.info(downloadedFile);
+      } else {
+        console.log('Submitted');
+      }
     })
   );
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -35,9 +35,7 @@ program
             missingKeys.join(', ')
         );
       }
-      if (!options.output && options.channel === 'unlisted') {
-        throw new Error('unlisted addons must have an output');
-      }
+
       const downloadedFile = await signAddon({
         apiKey: options.apiKey as string,
         apiSecret: options.apiSecret as string,
@@ -48,11 +46,7 @@ program
         sourceFile: options.sourceFile as string,
         output: options.output as string,
       });
-      if (downloadedFile) {
-        console.info(downloadedFile);
-      } else {
-        console.log('Submitted');
-      }
+      console.info(downloadedFile);
     })
   );
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -35,7 +35,6 @@ program
             missingKeys.join(', ')
         );
       }
-
       const downloadedFile = await signAddon({
         apiKey: options.apiKey as string,
         apiSecret: options.apiSecret as string,

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -48,11 +48,7 @@ program
         sourceFile: options.sourceFile as string,
         output: options.output as string,
       });
-      if (downloadedFile) {
-        console.info(downloadedFile);
-      } else {
-        console.log('Submitted');
-      }
+      console.info(downloadedFile);
     })
   );
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -35,6 +35,9 @@ program
             missingKeys.join(', ')
         );
       }
+      if (!options.output && options.channel === 'unlisted') {
+        throw new Error('unlisted addons must have an output');
+      }
       const downloadedFile = await signAddon({
         apiKey: options.apiKey as string,
         apiSecret: options.apiSecret as string,
@@ -45,7 +48,11 @@ program
         sourceFile: options.sourceFile as string,
         output: options.output as string,
       });
-      console.info(downloadedFile);
+      if (downloadedFile) {
+        console.info(downloadedFile);
+      } else {
+        console.log('Submitted');
+      }
     })
   );
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -35,9 +35,7 @@ program
             missingKeys.join(', ')
         );
       }
-      if (!options.output && options.channel === 'unlisted') {
-        throw new Error('unlisted addons must have an output');
-      }
+
       const downloadedFile = await signAddon({
         apiKey: options.apiKey as string,
         apiSecret: options.apiSecret as string,

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -35,6 +35,9 @@ program
             missingKeys.join(', ')
         );
       }
+      if (!options.output && options.channel === 'unlisted') {
+        throw new Error('unlisted addons must have an output');
+      }
       const downloadedFile = await signAddon({
         apiKey: options.apiKey as string,
         apiSecret: options.apiSecret as string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,9 @@ export async function signAddon({
 
   if (!output && channel === 'unlisted') {
     throw new Error('unlisted addons must have an output');
-  } else if (output) {
+  }
+
+  if (output) {
     signedFile = await poll(
       async () => {
         const file = await client.getSignedFile(addonId, addonVersion);

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,5 +281,5 @@ export async function signAddon({
     pollInterval,
     pollRetry
   );
-  return client.downloadFile(signedFile.download_url);
+  return client.downloadFile(signedFile.download_url, output);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,11 +266,7 @@ export async function signAddon({
     }
   }
 
-  if (!output && channel === 'unlisted') {
-    throw new Error('unlisted addons must have an output');
-  }
-
-  if (output) {
+  if (output || channel === 'unlisted') {
     signedFile = await poll(
       async () => {
         const file = await client.getSignedFile(addonId, addonVersion);
@@ -280,7 +276,7 @@ export async function signAddon({
       pollInterval,
       pollRetry
     );
-    return client.downloadFile(signedFile.download_url, output);
+    return client.downloadFile(signedFile.download_url);
   }
   // TODO: add fallback
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,14 +272,17 @@ export async function signAddon({
     );
   }
 
-  signedFile = await poll(
-    async () => {
-      const file = await client.getSignedFile(addonId, addonVersion);
-      if (!file) throw new Error('file not signed yet');
-      return file;
-    },
-    pollInterval,
-    pollRetry
-  );
-  return client.downloadFile(signedFile.download_url, output);
+  if (output) {
+    signedFile = await poll(
+      async () => {
+        const file = await client.getSignedFile(addonId, addonVersion);
+        if (!file) throw new Error('file not signed yet');
+        return file;
+      },
+      pollInterval,
+      pollRetry
+    );
+    return client.downloadFile(signedFile.download_url);
+  }
+  // TODO: add fallback
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,5 +281,5 @@ export async function signAddon({
     pollInterval,
     pollRetry
   );
-  return client.downloadFile(signedFile.download_url, output);
+  return client.downloadFile(signedFile.download_url);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,17 +272,14 @@ export async function signAddon({
     );
   }
 
-  if (output) {
-    signedFile = await poll(
-      async () => {
-        const file = await client.getSignedFile(addonId, addonVersion);
-        if (!file) throw new Error('file not signed yet');
-        return file;
-      },
-      pollInterval,
-      pollRetry
-    );
-    return client.downloadFile(signedFile.download_url);
-  }
-  // TODO: add fallback
+  signedFile = await poll(
+    async () => {
+      const file = await client.getSignedFile(addonId, addonVersion);
+      if (!file) throw new Error('file not signed yet');
+      return file;
+    },
+    pollInterval,
+    pollRetry
+  );
+  return client.downloadFile(signedFile.download_url, output);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ export async function signAddon({
   output,
   pollInterval = 15000,
   pollRetry = 4,
-}: SignAddonParam | undefined) {
+}: SignAddonParam) {
   const client = new AMOClient(apiKey, apiSecret);
   let signedFile: FileInfo;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,7 +266,9 @@ export async function signAddon({
     }
   }
 
-  if (output) {
+  if (!output && channel === 'unlisted') {
+    throw new Error('unlisted addons must have an output');
+  } else if (output) {
     signedFile = await poll(
       async () => {
         const file = await client.getSignedFile(addonId, addonVersion);

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,4 +282,5 @@ export async function signAddon({
     );
     return client.downloadFile(signedFile.download_url, output);
   }
+  // TODO: add fallback
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ export async function signAddon({
   output,
   pollInterval = 15000,
   pollRetry = 4,
-}: SignAddonParam) {
+}: SignAddonParam | undefined) {
   const client = new AMOClient(apiKey, apiSecret);
   let signedFile: FileInfo;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,14 +266,16 @@ export async function signAddon({
     }
   }
 
-  signedFile = await poll(
-    async () => {
-      const file = await client.getSignedFile(addonId, addonVersion);
-      if (!file) throw new Error('file not signed yet');
-      return file;
-    },
-    pollInterval,
-    pollRetry
-  );
-  return client.downloadFile(signedFile.download_url, output);
+  if (output) {
+    signedFile = await poll(
+      async () => {
+        const file = await client.getSignedFile(addonId, addonVersion);
+        if (!file) throw new Error('file not signed yet');
+        return file;
+      },
+      pollInterval,
+      pollRetry
+    );
+    return client.downloadFile(signedFile.download_url, output);
+  }
 }


### PR DESCRIPTION
A listed add-on often sometimes manual review, in which case the script currently fails with error "file not signed yet". To mitigate this, I made waiting for the signed file download optional with respect to whether the output path is provided.

On top of it, currently the linter complains about using single-quotes instead of double-quotes, for which I added a .prettierrc that makes the current code viable for the linter.