### PR TITLE
fix: fix sign command options & show global options in subcommand help

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn ci
+pnpm run ci

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -24,6 +24,7 @@ program
     'the API URL prefix, https://addons.mozilla.org if unspecified',
   )
   .option('--addon-id <addonId>', 'addon UUID which can be found in AMO')
+  .configureHelp({ showGlobalOptions: true })
   .version(pkg.packageJson.version);
 
 program

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -60,7 +60,11 @@ This command could be run multiple times to check the status, and the version wi
   )
   .option('--output <output>', 'the file path to save the signed XPI file')
   .action(
-    wrapError(async (options) => {
+    wrapError(async (_, command) => {
+      const options = {
+        ...loadFromEnv(),
+        ...command.optsWithGlobals(),
+      };
       verifyKeys(options, ['apiKey', 'apiSecret', 'addonId', 'addonVersion']);
       const downloadedFile = await signAddon({
         apiKey: options.apiKey as string,


### PR DESCRIPTION
Hello! It's me again. I was using this repo's CLI again and noticed that in v0.6.0's `sign` command was giving me this error:
![image](https://github.com/user-attachments/assets/0647f144-e397-482a-ae6f-10af7ec57aa6)
And after realizing from the check of https://github.com/violentmonkey/amo-upload/blob/959bc26a2fdc2c471465e6e4e5631f75d5e4da45/src/bin.ts#L64 my error only complained about every required option other than `addonVersion` which was explicitly defined inside the subcommand in https://github.com/violentmonkey/amo-upload/blob/959bc26a2fdc2c471465e6e4e5631f75d5e4da45/src/bin.ts#L29-L35 I found that for the `sign` command any of the global options weren't being passed at all. I noticed the `list` subcommand already has a solution for that in https://github.com/violentmonkey/amo-upload/blob/959bc26a2fdc2c471465e6e4e5631f75d5e4da45/src/bin.ts#L96-L102 so I copied it over to the `sign` command as well.

I also added the `showGlobalOptions` flag for commander.js mentioned in their [readme](https://github.com/tj/commander.js/tree/970ecae402b253de691e6a9066fea22f38fe7431?tab=readme-ov-file#more-configuration-2) and [example](https://github.com/tj/commander.js/blob/970ecae402b253de691e6a9066fea22f38fe7431/examples/global-options-nested.js#L1-L28) that I found while looking up info on the initial error.

> `showGlobalOptions`: show a section with the global options from the parent command(s)

I know v0.6.0 was pushed 10 months ago so I'm a bit late to the party, but would still appreciate having this CLI fix merged. Thanks!