### PR TITLE
feat: add retry-after-limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ $ npx amo-upload \
   --addon-version $VERSION \
   --channel listed \
   --dist-file path/to/dist.zip \
-  --source-file path/to/source.zip
+  --source-file path/to/source.zip \
+  --throttled-retry 120 \
   --output path/to/my-ext-v1.2.3.xpi
 ```
 
@@ -75,7 +76,9 @@ try {
     channel: 'listed',
     distFile: 'path/to/dist.zip',
     sourceFile: 'path/to/source.zip',
+    throttledRetry: 120,
     output: 'path/to/my-ext-v1.2.3.xpi',
+    onStatusChange: (status, data) => console.log(status, data),
   });
   console.info('The signed file is stored at:', output);
 } catch (err) {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ npx amo-upload \
   --channel listed \
   --dist-file path/to/dist.zip \
   --source-file path/to/source.zip \
-  --throttled-retry 120 \
+  --retry-after-limit 120 \
   --output path/to/my-ext-v1.2.3.xpi
 ```
 
@@ -76,7 +76,7 @@ try {
     channel: 'listed',
     distFile: 'path/to/dist.zip',
     sourceFile: 'path/to/source.zip',
-    throttledRetry: 120,
+    retryAfterLimit: 120,
     output: 'path/to/my-ext-v1.2.3.xpi',
   });
   console.info('The signed file is stored at:', output);

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ try {
     sourceFile: 'path/to/source.zip',
     throttledRetry: 120,
     output: 'path/to/my-ext-v1.2.3.xpi',
-    onStatusChange: (status, data) => console.log(status, data),
   });
   console.info('The signed file is stored at:', output);
 } catch (err) {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -71,6 +71,10 @@ This command could be run multiple times to check the status, and the version wi
         ...command.optsWithGlobals(),
       };
       verifyKeys(options, ['apiKey', 'apiSecret', 'addonId', 'addonVersion']);
+      let throttledRetry = Number(options.throttledRetry);
+      if (Number.isNaN(throttledRetry)) {
+        throttledRetry = 0;
+      }
       const downloadedFile = await signAddon({
         apiKey: options.apiKey as string,
         apiSecret: options.apiSecret as string,
@@ -87,7 +91,7 @@ This command could be run multiple times to check the status, and the version wi
         compatibility: options.compatibility
           ? (JSON.parse(options.compatibility) as CompatibilityInfo)
           : undefined,
-        throttledRetry: options.throttledRetry as number ?? 0,
+        throttledRetry,
         output: options.output as string,
       });
       console.info(downloadedFile);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -59,6 +59,10 @@ This command could be run multiple times to check the status, and the version wi
     '--compatibility <jsonString>',
     'the compatibility info as a JSON string, e.g. `["android","firefox"]`',
   )
+  .option(
+    '--throttled-retry <maxTime>',
+    'when a 429 throttled error occurs, if a retry is possible within maxTime, the request will wait for a certain period before being re-requested. e.g. 120',
+  )
   .option('--output <output>', 'the file path to save the signed XPI file')
   .action(
     wrapError(async (_, command) => {
@@ -83,6 +87,7 @@ This command could be run multiple times to check the status, and the version wi
         compatibility: options.compatibility
           ? (JSON.parse(options.compatibility) as CompatibilityInfo)
           : undefined,
+        throttledRetry: options.throttledRetry as number ?? 0,
         output: options.output as string,
       });
       console.info(downloadedFile);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -60,8 +60,8 @@ This command could be run multiple times to check the status, and the version wi
     'the compatibility info as a JSON string, e.g. `["android","firefox"]`',
   )
   .option(
-    '--throttled-retry <maxTime>',
-    'when a 429 throttled error occurs, if a retry is possible within maxTime, the request will wait for a certain period before being re-requested. e.g. 120',
+    '--retry-after-limit <maxTime>',
+    'when a throttled error occurs, if a retry is possible within this parameter, the request will wait for a certain period before being re-requested. e.g. 120',
   )
   .option('--output <output>', 'the file path to save the signed XPI file')
   .action(
@@ -71,9 +71,9 @@ This command could be run multiple times to check the status, and the version wi
         ...command.optsWithGlobals(),
       };
       verifyKeys(options, ['apiKey', 'apiSecret', 'addonId', 'addonVersion']);
-      let throttledRetry = Number(options.throttledRetry);
-      if (Number.isNaN(throttledRetry)) {
-        throttledRetry = 0;
+      let retryAfterLimit = Number(options.retryAfterLimit);
+      if (Number.isNaN(retryAfterLimit)) {
+        retryAfterLimit = 0;
       }
       const downloadedFile = await signAddon({
         apiKey: options.apiKey as string,
@@ -91,7 +91,7 @@ This command could be run multiple times to check the status, and the version wi
         compatibility: options.compatibility
           ? (JSON.parse(options.compatibility) as CompatibilityInfo)
           : undefined,
-        throttledRetry,
+        retryAfterLimit,
         output: options.output as string,
       });
       console.info(downloadedFile);

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export class AMOClient {
     const res = await this.fetch(this.apiPrefix + url, opts);
     const data = (await res.json()) as T;
     if (!res.ok) {
-      if (res.status === 429 &&  this.extra.throttledRetry && this.extra.throttledRetry > 0) {
+      if (res.status === 429 && this.extra.throttledRetry && this.extra.throttledRetry > 0) {
         const after = Number(res.headers.get('retry-after'));
         if (!Number.isNaN(after) && after <= this.extra.throttledRetry) {
           await setTimeout(after * 1000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,6 @@ async function poll<T>(
   throw lastError;
 }
 
-export interface AMOClientExtra {
-  retryAfterLimit?: number;
-}
-
 export class AMOClient {
   private headers: Record<string, string> = {};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,15 @@ import { Readable } from 'node:stream';
 import { finished } from 'node:stream/promises';
 import type { ReadableStream } from 'node:stream/web';
 import { setTimeout } from 'node:timers/promises';
-import type {
-  ChannelType,
-  CompatibilityInfo,
-  SignAddonParam,
-  UploadResponse,
-  VersionDetail,
-  VersionListRequest,
-  VersionListResponse,
+import {
+  SignAddonStatus,
+  type ChannelType,
+  type CompatibilityInfo,
+  type SignAddonParam,
+  type UploadResponse,
+  type VersionDetail,
+  type VersionListRequest,
+  type VersionListResponse,
 } from './types';
 
 const log = debug('amo-upload');
@@ -43,6 +44,10 @@ async function poll<T>(
   throw lastError;
 }
 
+export interface AMOClientExtra {
+  throttledRetry?: number;
+}
+
 export class AMOClient {
   private headers: Record<string, string> = {};
 
@@ -52,6 +57,7 @@ export class AMOClient {
     private apiKey: string,
     private apiSecret: string,
     public apiPrefix = 'https://addons.mozilla.org',
+    private extra: AMOClientExtra = {},
   ) {
     if (!apiKey || !apiSecret) {
       throw new Error('apiKey and apiSecret are required');
@@ -79,10 +85,19 @@ export class AMOClient {
     });
   }
 
-  private async request<T = unknown>(url: string, opts?: RequestInit) {
+  private async request<T = unknown>(url: string, opts?: RequestInit): Promise<T> {
     const res = await this.fetch(this.apiPrefix + url, opts);
     const data = (await res.json()) as T;
-    if (!res.ok) throw { res, data };
+    if (!res.ok) {
+      if (res.status === 429 &&  this.extra.throttledRetry && this.extra.throttledRetry > 0) {
+        const after = Number(res.headers.get('retry-after'));
+        if (!Number.isNaN(after) && after < this.extra.throttledRetry) {
+          await setTimeout(after * 1000);
+          return this.request<T>(url, opts);
+        }
+      }
+      throw { res, data };
+    }
     return data;
   }
 
@@ -320,10 +335,13 @@ export async function signAddon({
   pollInterval = 30000,
   pollRetry = 4,
   pollRetryExisting = 1,
+  throttledRetry = 0,
+  onStatusChange,
 }: SignAddonParam) {
-  const client = new AMOClient(apiKey, apiSecret, apiPrefix);
+  const client = new AMOClient(apiKey, apiSecret, apiPrefix, { throttledRetry });
 
   let versionDetail: VersionDetail | undefined;
+  onStatusChange?.(SignAddonStatus.BEFORE_GET_VERSION, versionDetail);
   try {
     versionDetail = await client.getVersion(addonId, addonVersion);
   } catch (err) {
@@ -331,23 +349,28 @@ export async function signAddon({
       throw err;
     }
   }
+  onStatusChange?.(SignAddonStatus.AFTER_GET_VERSION, versionDetail);
   const isNewVersion = !versionDetail;
   if (!versionDetail) {
     if (!distFile)
       throw new Error('Version not found, please provide distFile');
+    onStatusChange?.(SignAddonStatus.BEFORE_CREATE_VERSION, versionDetail);
     versionDetail = await client.createVersion(addonId, channel, distFile, {
       sourceFile,
       approvalNotes,
       releaseNotes,
       compatibility,
     });
+    onStatusChange?.(SignAddonStatus.AFTER_CREATE_VERSION, versionDetail);
   } else {
+    onStatusChange?.(SignAddonStatus.BEFORE_UPDATE_VERSION, versionDetail);
     versionDetail = await client.updateVersion(addonId, versionDetail, {
       sourceFile,
       approvalNotes,
       releaseNotes,
       override,
     });
+    onStatusChange?.(SignAddonStatus.AFTER_UPDATE_VERSION, versionDetail);
   }
   if (!output && channel === 'listed') {
     return versionDetail.file.url.slice(
@@ -356,6 +379,7 @@ export async function signAddon({
   }
 
   log('Starting polling for the signed file');
+  onStatusChange?.(SignAddonStatus.BEFORE_POLL_SIGNED_FILE, versionDetail);
   const signedFile = await poll(
     async (i) => {
       log('Polling %s', i);
@@ -367,5 +391,11 @@ export async function signAddon({
     isNewVersion ? pollRetry : pollRetryExisting,
     !isNewVersion,
   );
-  return client.downloadFile(signedFile.url, output);
+  onStatusChange?.(SignAddonStatus.AFTER_POLL_SIGNED_FILE, signedFile);
+
+  // Download signed file
+  onStatusChange?.(SignAddonStatus.BEFORE_DOWNLOAD_FILE, signedFile);
+  const res = client.downloadFile(signedFile.url, output);
+  onStatusChange?.(SignAddonStatus.AFTER_DOWNLOAD_FILE, res);
+  return res;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export class AMOClient {
     if (!res.ok) {
       if (res.status === 429 &&  this.extra.throttledRetry && this.extra.throttledRetry > 0) {
         const after = Number(res.headers.get('retry-after'));
-        if (!Number.isNaN(after) && after < this.extra.throttledRetry) {
+        if (!Number.isNaN(after) && after <= this.extra.throttledRetry) {
           await setTimeout(after * 1000);
           return this.request<T>(url, opts);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,14 @@ import { Readable } from 'node:stream';
 import { finished } from 'node:stream/promises';
 import type { ReadableStream } from 'node:stream/web';
 import { setTimeout } from 'node:timers/promises';
-import {
-  SignAddonStatus,
-  type ChannelType,
-  type CompatibilityInfo,
-  type SignAddonParam,
-  type UploadResponse,
-  type VersionDetail,
-  type VersionListRequest,
-  type VersionListResponse,
+import type {
+  ChannelType,
+  CompatibilityInfo,
+  SignAddonParam,
+  UploadResponse,
+  VersionDetail,
+  VersionListRequest,
+  VersionListResponse,
 } from './types';
 
 const log = debug('amo-upload');
@@ -337,12 +336,10 @@ export async function signAddon({
   pollRetry = 4,
   pollRetryExisting = 1,
   throttledRetry = 0,
-  onStatusChange,
 }: SignAddonParam) {
   const client = new AMOClient(apiKey, apiSecret, apiPrefix, { throttledRetry });
 
   let versionDetail: VersionDetail | undefined;
-  onStatusChange?.(SignAddonStatus.BEFORE_GET_VERSION, versionDetail);
   try {
     versionDetail = await client.getVersion(addonId, addonVersion);
   } catch (err) {
@@ -350,28 +347,23 @@ export async function signAddon({
       throw err;
     }
   }
-  onStatusChange?.(SignAddonStatus.AFTER_GET_VERSION, versionDetail);
   const isNewVersion = !versionDetail;
   if (!versionDetail) {
     if (!distFile)
       throw new Error('Version not found, please provide distFile');
-    onStatusChange?.(SignAddonStatus.BEFORE_CREATE_VERSION, versionDetail);
     versionDetail = await client.createVersion(addonId, channel, distFile, {
       sourceFile,
       approvalNotes,
       releaseNotes,
       compatibility,
     });
-    onStatusChange?.(SignAddonStatus.AFTER_CREATE_VERSION, versionDetail);
   } else {
-    onStatusChange?.(SignAddonStatus.BEFORE_UPDATE_VERSION, versionDetail);
     versionDetail = await client.updateVersion(addonId, versionDetail, {
       sourceFile,
       approvalNotes,
       releaseNotes,
       override,
     });
-    onStatusChange?.(SignAddonStatus.AFTER_UPDATE_VERSION, versionDetail);
   }
   if (!output && channel === 'listed') {
     return versionDetail.file.url.slice(
@@ -380,7 +372,6 @@ export async function signAddon({
   }
 
   log('Starting polling for the signed file');
-  onStatusChange?.(SignAddonStatus.BEFORE_POLL_SIGNED_FILE, versionDetail);
   const signedFile = await poll(
     async (i) => {
       log('Polling %s', i);
@@ -392,11 +383,7 @@ export async function signAddon({
     isNewVersion ? pollRetry : pollRetryExisting,
     !isNewVersion,
   );
-  onStatusChange?.(SignAddonStatus.AFTER_POLL_SIGNED_FILE, signedFile);
 
   // Download signed file
-  onStatusChange?.(SignAddonStatus.BEFORE_DOWNLOAD_FILE, signedFile);
-  const res = client.downloadFile(signedFile.url, output);
-  onStatusChange?.(SignAddonStatus.AFTER_DOWNLOAD_FILE, res);
-  return res;
+  return client.downloadFile(signedFile.url, output);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ async function poll<T>(
 }
 
 export interface AMOClientExtra {
-  throttledRetry?: number;
+  retryAfterLimit?: number;
 }
 
 export class AMOClient {
@@ -88,9 +88,9 @@ export class AMOClient {
     const res = await this.fetch(this.apiPrefix + url, opts);
     const data = (await res.json()) as T;
     if (!res.ok) {
-      if (res.status === 429 && this.extra.throttledRetry && this.extra.throttledRetry > 0) {
+      if (res.headers.has('retry-after') && this.extra.retryAfterLimit && this.extra.retryAfterLimit > 0) {
         const after = Number(res.headers.get('retry-after'));
-        if (!Number.isNaN(after) && after <= this.extra.throttledRetry) {
+        if (!Number.isNaN(after) && after <= this.extra.retryAfterLimit) {
           // wait one more second
           await setTimeout(after * 1000 + 1000);
           return this.request<T>(url, opts);
@@ -335,9 +335,9 @@ export async function signAddon({
   pollInterval = 30000,
   pollRetry = 4,
   pollRetryExisting = 1,
-  throttledRetry = 0,
+  retryAfterLimit = 0,
 }: SignAddonParam) {
-  const client = new AMOClient(apiKey, apiSecret, apiPrefix, { throttledRetry });
+  const client = new AMOClient(apiKey, apiSecret, apiPrefix, { retryAfterLimit });
 
   let versionDetail: VersionDetail | undefined;
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,8 @@ export class AMOClient {
       if (res.status === 429 && this.extra.throttledRetry && this.extra.throttledRetry > 0) {
         const after = Number(res.headers.get('retry-after'));
         if (!Number.isNaN(after) && after <= this.extra.throttledRetry) {
-          await setTimeout(after * 1000);
+          // wait one more second
+          await setTimeout(after * 1000 + 1000);
           return this.request<T>(url, opts);
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,23 +53,6 @@ export interface UploadResponse {
   validation: object;
 }
 
-export enum SignAddonStatus {
-  BEFORE_GET_VERSION = 'before_get_version',
-  AFTER_GET_VERSION = 'after_get_version',
-  // createVersion
-  BEFORE_CREATE_VERSION = 'before_create_version',
-  AFTER_CREATE_VERSION = 'after_create_version',
-  // updateVersion
-  BEFORE_UPDATE_VERSION = 'before_update_version',
-  AFTER_UPDATE_VERSION = 'after_update_version',
-  // poll signed file
-  BEFORE_POLL_SIGNED_FILE = 'before_poll_signed_file',
-  AFTER_POLL_SIGNED_FILE = 'after_poll_signed_file',
-  // download file
-  BEFORE_DOWNLOAD_FILE = 'before_download_file',
-  AFTER_DOWNLOAD_FILE = 'after_download_file',
-}
-
 export interface SignAddonParam {
   apiKey: string;
   apiSecret: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,23 @@ export interface UploadResponse {
   validation: object;
 }
 
+export enum SignAddonStatus {
+  BEFORE_GET_VERSION = 'before_get_version',
+  AFTER_GET_VERSION = 'after_get_version',
+  // createVersion
+  BEFORE_CREATE_VERSION = 'before_create_version',
+  AFTER_CREATE_VERSION = 'after_create_version',
+  // updateVersion
+  BEFORE_UPDATE_VERSION = 'before_update_version',
+  AFTER_UPDATE_VERSION = 'after_update_version',
+  // poll signed file
+  BEFORE_POLL_SIGNED_FILE = 'before_poll_signed_file',
+  AFTER_POLL_SIGNED_FILE = 'after_poll_signed_file',
+  // download file
+  BEFORE_DOWNLOAD_FILE = 'before_download_file',
+  AFTER_DOWNLOAD_FILE = 'after_download_file',
+}
+
 export interface SignAddonParam {
   apiKey: string;
   apiSecret: string;
@@ -72,4 +89,8 @@ export interface SignAddonParam {
   pollRetry?: number;
   /** Times to check the signed file for an existing version. */
   pollRetryExisting?: number;
+  // when a 429 throttled error occurs, if a retry is possible within maxTime, the system will wait until that time before retrying
+  throttledRetry?: number;
+  // status change callback
+  onStatusChange?: (status: SignAddonStatus, data?: unknown) => void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,4 @@ export interface SignAddonParam {
   pollRetryExisting?: number;
   // when a 429 throttled error occurs, if a retry is possible within maxTime, the system will wait until that time before retrying
   throttledRetry?: number;
-  // status change callback
-  onStatusChange?: (status: SignAddonStatus, data?: unknown) => void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export type AMOClientActions =
 
 export interface AMOClientOptions {
   onDebug?: (type: AMOClientActions, payload?: unknown) => void;
-  // when a throttled error occurs, if a retry is possible within this parameter, the system will wait until that time before retrying
+  /** When a throttled error occurs, if a retry is possible within this parameter, the system will wait until that time before retrying. */
   retryAfterLimit?: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,6 @@ export interface SignAddonParam {
   pollRetry?: number;
   /** Times to check the signed file for an existing version. */
   pollRetryExisting?: number;
-  // when a 429 throttled error occurs, if a retry is possible within maxTime, the system will wait until that time before retrying
-  throttledRetry?: number;
+  // when a throttled error occurs, if a retry is possible within this parameter, the system will wait until that time before retrying
+  retryAfterLimit?: number;
 }


### PR DESCRIPTION
AMO limits the frequency of API calls. When the limit is exceeded, a 429 error is returned, requiring a retry after a certain period of time. Such as:

<img height="600" alt="image" src="https://github.com/user-attachments/assets/b4604c50-aebc-442c-9c1e-b720c7c16604" />

A new `retry-after-limit` parameter has been added. If the request can be retried (a `retry-after` header exists) and the retry time is less than the `retry-after-limit` parameter, the request will be re-initiated after waiting for `retry-after` seconds.